### PR TITLE
Adds option for lazy connection to swift

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-storage-swift',
-    version='1.2.17',
+    version='1.2.18',
     description='OpenStack Swift storage backend for Django',
     long_description=open('README.rst').read(),
     url='https://github.com/dennisv/django-storage-swift',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -159,6 +159,14 @@ class ConfigTest(SwiftStorageTestCase):
         with self.assertRaises(ImproperlyConfigured):
             self.default_storage('v3', os_extra_options="boom!")
 
+    @patch.object(FakeSwift.Connection, '__init__', return_value=None)
+    def test_override_lazy_connect(self, mock_swift_init):
+        """Test setting lazy_connect delays connection creation"""
+        backend = self.default_storage('v3', lazy_connect=True)
+        assert not mock_swift_init.called
+        self.assertFalse(backend.exists('warez/some_random_movie.mp4'))
+        assert mock_swift_init.called
+
 
 # @patch('swift.storage.swiftclient', new=FakeSwift)
 # class TokenTest(SwiftStorageTestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,6 +91,7 @@ class FakeSwift(object):
     containers = ['container']
 
     class Connection(object):
+        service_token = None
         def __init__(self, authurl=None, user=None, key=None, retries=5,
                      preauthurl=None, preauthtoken=None, snet=False,
                      starting_backoff=1, max_backoff=64, tenant_name=None,
@@ -98,7 +99,7 @@ class FakeSwift(object):
                      insecure=False, cert=None, cert_key=None,
                      ssl_compression=True, retry_on_ratelimit=False,
                      timeout=None, session=None):
-            self.service_token = None
+            pass
 
         def _retry(self, reset_func, func, *args, **kwargs):
             self.url, self.token = self.get_auth()


### PR DESCRIPTION
Instead of connecting to SWIFT on storage init, this adds an option to allow the SWIFT connection to be created only when required.

Django takes great care to initialise Storage classes lazily, and so connecting on creation is generally a valid option.  However there are some cases where this is difficult to do, e.g., when using [`FileField.storage`](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.FileField.storage), the Storage instance is instantiated on model import time, which can result in unintended SWIFT authentication/connections.

**Reviewer**:

- [ ] @smarnach