### PR TITLE
Adds SWIFT_CONTENT_LENGTH_FROM_FD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,11 @@ Troubleshooting
    discussion <http://support.rc.nectar.org.au/forum/viewtopic.php?f=6&t=272>`__.
    If you are using temporary URLs, verify that your key is set
    correctly.
+-  **I'm getting empty or truncated file uploads**: Issues with some content
+   types may cause an incorrect `content_length` header to be sent with file
+   uploads, resulting in 0 byte or truncated files.  To avoid this, set
+   `SWIFT_CONTENT_LENGTH_FROM_FD: True`.
+
 
 Quickstart
 ----------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-storage-swift',
-    version='1.2.18',
+    version='1.2.19',
     description='OpenStack Swift storage backend for Django',
     long_description=open('README.rst').read(),
     url='https://github.com/dennisv/django-storage-swift',

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -142,6 +142,7 @@ class SwiftStorage(Storage):
     auto_overwrite = setting('SWIFT_AUTO_OVERWRITE', False)
     lazy_connect = setting('SWIFT_LAZY_CONNECT', False)
     content_type_from_fd = setting('SWIFT_CONTENT_TYPE_FROM_FD', False)
+    content_length_from_fd = setting('SWIFT_CONTENT_LENGTH_FROM_FD', True)
     _token_creation_time = 0
     _token = ''
     _swift_conn = None
@@ -265,7 +266,12 @@ class SwiftStorage(Storage):
             content.seek(0)
         else:
             content_type = mimetypes.guess_type(name)[0]
-        content_length = content.size
+
+        if self.content_length_from_fd:
+            content_length = content.size
+        else:
+            content_length = None
+
         self.swift_conn.put_object(self.container_name,
                                    name,
                                    content,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -303,7 +303,6 @@ class BackendTest(SwiftStorageTestCase):
         content = dict(orig="Hello world!")
         content_file = ContentFile("")
         content_file.write(content['orig'])
-        self.assertEqual(content_file.size, 0)
 
         def mocked_put_object(cls, url, token, container, name=None,
                               contents=None, content_length=None, *args, **kwargs):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -288,12 +288,32 @@ class BackendTest(SwiftStorageTestCase):
         content_file.seek(5)
 
         def mocked_put_object(cls, url, token, container, name=None,
-                              contents=None, *args, **kwargs):
+                              contents=None, content_length=None, *args, **kwargs):
             content['saved'] = contents.read()
+            content['size'] = content_length
 
         with patch('tests.utils.FakeSwift.put_object', new=classmethod(mocked_put_object)):
             self.backend.save('test.txt', content_file)
         self.assertEqual(content['saved'], content['orig'])
+        self.assertEqual(content['size'], len(content['orig']))
+
+    def test_no_content_length_from_fd(self):
+        """Test disabling content_length_from_fd on save"""
+        backend = self.default_storage('v3', content_length_from_fd=False)
+        content = dict(orig="Hello world!")
+        content_file = ContentFile("")
+        content_file.write(content['orig'])
+        self.assertEqual(content_file.size, 0)
+
+        def mocked_put_object(cls, url, token, container, name=None,
+                              contents=None, content_length=None, *args, **kwargs):
+            content['saved'] = contents.read()
+            content['size'] = content_length
+
+        with patch('tests.utils.FakeSwift.put_object', new=classmethod(mocked_put_object)):
+            backend.save('test.txt', content_file)
+        self.assertEqual(content['saved'], content['orig'])
+        self.assertIsNone(content['size'])
 
     def test_open(self):
         """Attempt to open a object"""


### PR DESCRIPTION
Adds `SWIFT_CONTENT_LENGTH_FROM_FD` with default `True`, which preserves the current behaviour by inferring the `content_length` header from the Django File object's `size` attribute when saving the object.

Using `SWIFT_CONTENT_LENGTH_FROM_FD: False` will send `content_length = None`, allowing the SWIFT backend to determine the content length using the content read.

This is a workaround for a bug we encountered with [Django ContentFile](https://docs.djangoproject.com/en/2.0/_modules/django/core/files/base/#ContentFile) objects (prior to Django2) which can mis-report their size if changed after initialisation. See added [`test_no_content_length_from_fd()`](https://github.com/dennisv/django-storage-swift/pull/100/files#diff-61d51a325171d97c8a56e59ea525339bR306) for example.

**Reviewers**
- [x] @clemente