### PR TITLE
Move `def setting()` to utils.py

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -8,11 +8,12 @@ from io import BytesIO, UnsupportedOperation
 from time import time
 
 import magic
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.files.storage import Storage
 from six.moves.urllib import parse as urlparse
+
+from swift.utils import setting
 
 try:
     from django.utils.deconstruct import deconstructible
@@ -25,10 +26,6 @@ try:
     from swiftclient.utils import generate_temp_url
 except ImportError:
     raise ImproperlyConfigured("Could not load swiftclient library")
-
-
-def setting(name, default=None):
-    return getattr(settings, name, default)
 
 
 def validate_settings(backend):

--- a/swift/utils.py
+++ b/swift/utils.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+def setting(name, default=None):
+    return getattr(settings, name, default)


### PR DESCRIPTION
Hi,

This is to duplicate what's done in the `django-storage` module. 3rd party apps relies on that structure to be able to monkey patch that function and inject configuration options direcly. For example Netbox (see https://github.com/netbox-community/netbox/issues/14554)

Tested and works as expected, no backward compatibility issue that I can think of.
Let me know if you have any questions.

Thank you !